### PR TITLE
ALW-24 & #64: Fix download button again

### DIFF
--- a/src/pages/data_dashboard.py
+++ b/src/pages/data_dashboard.py
@@ -643,7 +643,15 @@ with containers[5]:
             figs[4] = fig
             st.plotly_chart(figs[4], config=plot_config)
 
-if (mins_played > 0) and (played_90s >= min_90s):
+if (
+    (mins_played > 0)
+    and (played_90s >= min_90s)
+    and (
+        len(attacking_metrics) == 2
+        and len(passing_metrics) == 2
+        and len(defending_metrics) == 2
+    )
+):
     download.data_dashboard(
         minutes_played=mins_played,
         played_90s=played_90s,


### PR DESCRIPTION
Fix bug no.3: Download button on the Data Dashboard page still shows up if there are less than 2 metrics selected for one scatter plot. This causes the app to throw an error below the dashboard since the button wrapper assumes all `metrics_selection` arrays being passed to it has a minimum of 6 metrics (len of 5).